### PR TITLE
Page generation overhaul

### DIFF
--- a/config/cache.yaml
+++ b/config/cache.yaml
@@ -4,7 +4,7 @@ cache:
     content: 60
     output: 60
     assets: 3600
-  driver: filesystem
+  driver: ephemeral
   driver_filesystem_config:
     encoder: Native
     path: ${cache.directory}CacheProvider

--- a/demo/content/index.md
+++ b/demo/content/index.md
@@ -2,11 +2,9 @@ Welcome to a website!
 
 This is a bit of test content.
 
-<ul>
 {% for p in page.children.sortBy('date.modified',true) %}
-<li>{{p|link}}</li>
+* {{p|link}}
 {% endfor %}
-</ul>
 
 <!--@meta 
 name: Home

--- a/src/Leafcutter.php
+++ b/src/Leafcutter.php
@@ -83,7 +83,7 @@ class Leafcutter
                 $response->setStatus(404);
             }
             if ($page) {
-                $response->setContent($page->content());
+                $response->setContent($page->generateContent());
             } else {
                 $response->setStatus(404);
                 $response->setContent('<!doctype html><html><body><h1>404 not found</h1><p>Additionally, no error page could be located.</p></body></html>');

--- a/src/Pages/PageInterface.php
+++ b/src/Pages/PageInterface.php
@@ -8,7 +8,7 @@ interface PageInterface
 {
     public function __construct(URL $url);
     public function url(): URL;
-    public function calledURL(): URL;
+    public function calledUrl(): URL;
     public function setUrl(URL $url);
     public function rawContent(): string;
     public function generateContent(): string;

--- a/src/Pages/PageInterface.php
+++ b/src/Pages/PageInterface.php
@@ -6,12 +6,13 @@ use Leafcutter\URL;
 
 interface PageInterface
 {
-    public function __construct(URL $url, string $content);
+    public function __construct(URL $url);
     public function url(): URL;
     public function calledURL(): URL;
     public function setUrl(URL $url);
-    public function content(): string;
-    public function setContent($content);
+    public function rawContent(): string;
+    public function generateContent(): string;
+    public function setRawContent(string $content);
     public function hash(): string;
     public function children(): Collection;
     public function parent(): ?PageInterface;

--- a/src/Pages/PageProvider.php
+++ b/src/Pages/PageProvider.php
@@ -28,7 +28,7 @@ class PageProvider
                 $meta = Yaml::parse($match[1]);
                 $page->metaMerge($meta);
             } catch (\Throwable $th) {
-                Leafcutter::get()->logger()->error('Failed to parse meta yaml content for ' . $page->calledURL());
+                Leafcutter::get()->logger()->error('Failed to parse meta yaml content for ' . $page->calledUrl());
             }
             return '';
         }, $event->content());

--- a/src/Pages/PageProvider.php
+++ b/src/Pages/PageProvider.php
@@ -19,24 +19,27 @@ class PageProvider
         $this->leafcutter->events()->addSubscriber($this);
     }
 
-    public function onPageContent(PageContentEvent $event)
+    public function onPageSetRawContent(PageContentEvent $event)
     {
-        $content = $event->content();
         $page = $event->page();
+        // try to parse out any @meta comments
         $content = preg_replace_callback('/<!--@meta(.+?)-->/ms', function ($match) use ($page) {
             try {
                 $meta = Yaml::parse($match[1]);
                 $page->metaMerge($meta);
             } catch (\Throwable $th) {
                 Leafcutter::get()->logger()->error('Failed to parse meta yaml content for ' . $page->calledURL());
-                // throw $th;
             }
             return '';
-        }, $content);
-        $event->setContent($content);
-        if (!$page->meta('name') && preg_match('@<h1>(.+?)</h1>@', $content, $matches)) {
+        }, $event->content());
+        // try to identify something like an HTML header tag
+        if (!$page->meta('name') && preg_match('@^<h1>(.+?)</h1>$@m', $content, $matches)) {
             $page->meta('name', trim(strip_tags($matches[1])));
         }
+        if (!$page->meta('name') && preg_match('@^#(.+)$@m', $content, $matches)) {
+            $page->meta('name', trim(strip_tags($matches[1])));
+        }
+        $event->setContent($content);
     }
 
     public function parent(URL $url): ?PageInterface
@@ -93,26 +96,33 @@ class PageProvider
 
     public function onPageFile_md(PageFileEvent $e)
     {
-        $content = $e->getContents();
-        $content = $this->markdown()->text($content);
-        $url = $e->url();
-        $url->setQuery([]);
-        $page = new Page($url, $content);
-        return $page;
+        return $this->handle_onPageFile($e, 'md');
+    }
+
+    public function onPageGenerateContent_build_md(PageContentEvent $e)
+    {
+        $e->setContent(
+            $this->markdown()->text($e->content())
+        );
     }
 
     public function onPageFile_html(PageFileEvent $e)
     {
-        $content = $e->getContents();
-        $url = $e->url();
-        $url->setQuery([]);
-        $page = new Page($url, $content);
-        return $page;
+        return $this->handle_onPageFile($e, 'html');
     }
 
     public function onPageFile_htm(PageFileEvent $e)
     {
-        return $this->onPageFile_html($e);
+        return $this->handle_onPageFile($e, 'html');
+    }
+
+    protected function handle_onPageFile(PageFileEvent $e, string $type = null)
+    {
+        $url = $e->url();
+        $url->setQuery([]);
+        $page = new Page($url);
+        $page->setRawContent($e->getContents(), $type);
+        return $page;
     }
 
     public function error(URL $url, int $code, int $originalCode = null): ?PageInterface

--- a/src/Templates/TemplateProvider.php
+++ b/src/Templates/TemplateProvider.php
@@ -2,6 +2,7 @@
 namespace Leafcutter\Templates;
 
 use Leafcutter\Leafcutter;
+use Leafcutter\Pages\PageContentEvent;
 use Leafcutter\Pages\PageEvent;
 use Leafcutter\Response;
 use Leafcutter\URLFactory;
@@ -70,23 +71,19 @@ class TemplateProvider
         $this->twig = null;
     }
 
-    public function onPageReady(PageEvent $event)
+    public function onPageGenerateContent_raw(PageContentEvent $event)
     {
         $page = $event->page();
-        $content = $page->content(false);
-        $name = 'page_' . $page->hash();
-        $page->setContent(function () use ($name, $page, $content) {
-            URLFactory::beginContext($page->calledURL());
-            $this->addOverride($name, $content);
-            $content = $this->apply(
-                $name,
-                [
-                    'page' => $page,
-                ]
-            );
-            URLFactory::endContext();
-            return $content;
-        });
+        $content = $event->content(false);
+        $name = 'onPageGenerateContent_'.$page->hash();
+        $this->addOverride($name, $content);
+        $content = $this->apply(
+            $name,
+            [
+                'page' => $page,
+            ]
+        );
+        $event->setContent($content);
     }
 
     protected function sourceDirectoriesChanged()

--- a/src/Themes/ThemeEvents.php
+++ b/src/Themes/ThemeEvents.php
@@ -194,7 +194,7 @@ class ThemeEvents
             $this->leafcutter->theme()->activate($name);
         }
         // specific css/js from page meta
-        URLFactory::beginContext($page->calledURL());
+        URLFactory::beginContext($page->calledUrl());
         foreach ($page->meta('page_js') ?? [] as $url) {
             $url = new URL($url);
             $this->leafcutter->theme()->addJs('page_js_' . md5($url), $url, 'page');

--- a/tests/units/Pages/Page.php
+++ b/tests/units/Pages/Page.php
@@ -1,0 +1,13 @@
+<?php
+namespace Leafcutter\tests\units\Pages;
+
+use atoum;
+use Leafcutter\URL;
+
+class Page extends atoum\test
+{
+    public function testConstruct()
+    {
+        $this->newTestedInstance(new URL('https://www.google.com/foo/bar.html'));
+    }
+}

--- a/tests/units/Pages/Page.php
+++ b/tests/units/Pages/Page.php
@@ -2,12 +2,138 @@
 namespace Leafcutter\tests\units\Pages;
 
 use atoum;
+use Leafcutter\Leafcutter;
+use Leafcutter\Pages\Page as PagesPage;
 use Leafcutter\URL;
+use Leafcutter\URLFactory;
 
 class Page extends atoum\test
 {
     public function testConstruct()
     {
-        $this->newTestedInstance(new URL('https://www.google.com/foo/bar.html'));
+        $this->newTestedInstance(new URL('https://www.google.com/foo/bar'));
+        $this->string($this->testedInstance->url()->__toString())
+            ->isEqualTo('https://www.google.com/foo/bar/')
+            ->boolean($this->testedInstance->dynamic())->isFalse()
+            ->given($this->testedInstance->setDynamic(true))
+                ->boolean($this->testedInstance->dynamic())->isTrue
+            ->string($this->testedInstance->template())->isEqualTo('default.twig')
+            ->given($this->testedInstance->setTemplate('foo.twig'))
+                ->string($this->testedInstance->template())->isEqualTo('foo.twig')
+            ->given($this->testedInstance->setUrl(new URL('https://www.google.com/foo/baz/')))
+                ->string($this->testedInstance->url()->__toString())
+                    ->isEqualTo('https://www.google.com/foo/baz/')
+                ->string($this->testedInstance->calledUrl()->__toString())
+                    ->isEqualTo('https://www.google.com/foo/bar/')
+            ->string($this->testedInstance->hash())
+        ;
+    }
+
+    public function testContent()
+    {
+        URLFactory::beginSite('http://www.google.com/');
+        $leafcutter = new \mock\Leafcutter();
+        Leafcutter::beginContext($leafcutter);
+        $this->given($page = new PagesPage(new URL('http://www.google.com/foo/bar.html')))
+            ->string($page->rawContent())
+                ->isEqualTo('No content')
+            ->string($page->generateContent())
+                ->isEqualTo('No content')
+            ->given($page->setRawContent("# Markdown\n\nPage content", 'md'))
+                ->string($page->rawContent())
+                    ->isEqualTo("# Markdown\n\nPage content")
+                ->string($page->generateContent())
+                    ->contains('<h1>')
+        ;
+        Leafcutter::endContext();
+        URLFactory::endSite();
+    }
+
+    public function testChildren()
+    {
+        URLFactory::beginSite('http://www.google.com/');
+        $leafcutter = new \mock\Leafcutter();
+        Leafcutter::beginContext($leafcutter);
+        $this->given($page = new PagesPage(new URL('http://www.google.com/foo/bar.html')))
+            ->object($page->children());
+        ;
+        Leafcutter::endContext();
+        URLFactory::endSite();
+    }
+
+    public function testBreadcrumb()
+    {
+        $leafcutter = new \mock\Leafcutter();
+        Leafcutter::beginContext($leafcutter);
+        $this->given($page = new PagesPage(new URL('http://www.google.com/foo/bar.html')))
+            ->and($parent = new PagesPage(new URL('http://www.google.com/foo/')))
+            ->and($page->setParent($parent))
+                ->object($page->parent())
+                    ->isEqualTo($parent)
+                ->array($page->breadcrumb())
+                    ->contains($page)
+                    ->contains($parent)
+                    ->hasSize(2)
+            ->given($parent->setParent($page))
+                ->object($parent->parent())
+                    ->isEqualTo($page)
+                ->array($page->breadcrumb())
+                    ->contains($page)
+                    ->contains($parent)
+                    ->hasSize(2)
+            ->given($parent->setParent('@/'))
+                ->variable($parent->parent())->isNull()
+                ->array($page->breadcrumb())
+                    ->contains($page)
+                    ->contains($parent)
+                    ->hasSize(2)
+        ;
+        Leafcutter::endContext();
+    }
+
+    public function testMeta()
+    {
+        $this->given($this->newTestedInstance(new URL('https://www.google.com/foo/bar.html')))
+            ->given($this->testedInstance->metaMerge(['foo'=>'bar']))
+                ->string($this->testedInstance->meta('foo'))
+                    ->isEqualTo('bar')
+            ->given($this->testedInstance->meta('date.test','January 1, 1980, 12:00 pm MDT'))
+                ->integer($this->testedInstance->meta('date.test'))
+            ->given($this->testedInstance->metaMerge(['date.foo'=>'January 1, 1980, 12:00 pm MDT']))
+                ->integer($this->testedInstance->meta('date.foo'))
+                    ->isEqualTo($this->testedInstance->meta('date.test'))
+        ;
+    }
+
+    public function testNameAndTitle()
+    {
+        // default untitled strings
+        $this->given($this->newTestedInstance(new URL('https://www.google.com/foo/bar.html')))
+            ->string($this->testedInstance->name())
+                ->isEqualTo('Unnamed page')
+            ->string($this->testedInstance->title())
+                ->isEqualTo('Untitled page');
+        // name set but not title
+        $this->given($this->newTestedInstance(new URL('https://www.google.com/foo/bar.html')))
+        ->and($this->testedInstance->meta('name','Named page'))
+            ->string($this->testedInstance->name())
+                ->isEqualTo('Named page')
+            ->string($this->testedInstance->title())
+                ->isEqualTo('Named page');
+        // title set but not name
+        $this->given($this->newTestedInstance(new URL('https://www.google.com/foo/bar.html')))
+        ->and($this->testedInstance->meta('title','Titled page'))
+            ->string($this->testedInstance->name())
+                ->isEqualTo('Titled page')
+            ->string($this->testedInstance->title())
+                ->isEqualTo('Titled page');
+        // name and title set
+        $this->given($this->newTestedInstance(new URL('https://www.google.com/foo/bar.html')))
+        ->and($this->testedInstance->meta('title','Titled page'))
+        ->and($this->testedInstance->meta('name','Named page'))
+            ->string($this->testedInstance->name())
+                ->isEqualTo('Named page')
+            ->string($this->testedInstance->title())
+                ->isEqualTo('Titled page');
     }
 }

--- a/tests/units/Response.php
+++ b/tests/units/Response.php
@@ -92,7 +92,7 @@ class Response extends atoum\test
     {
         $this->given($this->newTestedInstance)
             ->given($url = new \mock\Leafcutter\URL('https://www.google.com/'))
-            ->given($page = new \mock\Leafcutter\Pages\PageInterface($url, 'page content'))
+            ->given($page = new \mock\Leafcutter\Pages\PageInterface($url))
                 ->given($this->calling($page)->url = $url)
             ->given($this->testedInstance->setSource($page))
                 ->object($this->testedInstance->page())->isEqualTo($page)


### PR DESCRIPTION
Somewhat large reorganization of how page content is generated. Now instead of generating page content whenever it is requested, page content is set in a "raw" form, with a "type" specified.

Then either `rawContent()` or `generateContent()` can be used to access the original raw content, or the generated content, respectively. The actual generated content isn't built until `generateContent()` is called.

Since the `Page` class now only deals in strings, the previous trick of passing a callback into `setContent()` will no longer work, and pages may even become properly cacheable (although that's a problem for another day). Wherever you would have used a callback, you can now use an event hook.

The following new events are available (they occur in this order)

- onPageRawContent
- onPageRawContent_{type}
- onPageGenerateContent_raw
- onPageGenerateContent_raw_type
- onPageGenerateContent_build
- onPageGenerateContent_build_type
- onPageGenerateContent_finalize
- onPageGenerateContent_finalize_type