### PR TITLE
New core provider for indexing pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,14 @@
 *.ignore
 *.log
 
-/demo/assets
+/demo/assets/*
 /demo/cache
 /demo/**/*.html
 /demo/content/*
 !/demo/content/index.md
 env.yaml
+/demo/storage/*
+!/demo/**/README.md
 
 /src/Composer/*.txt
 /src/Composer/themes/*

--- a/content/_error_pages/300/index.md
+++ b/content/_error_pages/300/index.md
@@ -1,0 +1,7 @@
+# Multiple options
+
+The requested URL refers to more than one page. Please select an option below:
+
+{% for p in page.meta('300-options') %}
+* {{p|link}}
+{% endfor %}

--- a/content/_error_pages/300/index.md
+++ b/content/_error_pages/300/index.md
@@ -2,6 +2,6 @@
 
 The requested URL refers to more than one page. Please select an option below:
 
-{% for p in page.meta('300-options') %}
+{% for p in page.meta('pages.related').sortBy('name') %}
 * {{p|link}}
 {% endfor %}

--- a/content/_error_pages/404/index.md
+++ b/content/_error_pages/404/index.md
@@ -1,3 +1,14 @@
 # 404 not found
 
 Nothing was found at the requested URL.
+
+{% if page.meta('pages.related') %}
+## Possible results
+
+The following pages may be related to any content that used to exist here.
+
+{% for p in page.meta('pages.related').sortBy('name') %}
+* {{p|link}}
+{% endfor %}
+
+{% endif %}

--- a/content/_error_pages/999/index.md
+++ b/content/_error_pages/999/index.md
@@ -1,3 +1,3 @@
-# Unknown error
+# Unknown error {{page.meta('error.code')}}
 
 An unknown error code was requested.

--- a/demo/assets/README.md
+++ b/demo/assets/README.md
@@ -1,0 +1,3 @@
+# Assets folder
+
+Leafcutter requires a publicly-accessible directory to store processed asset files in.

--- a/demo/storage/README.md
+++ b/demo/storage/README.md
@@ -1,0 +1,3 @@
+# Storage folder
+
+Leafcutter requires a permanent storage folder, so that addons can store data somewhere and rely on getting it back out.

--- a/src/DOM/DOMProvider.php
+++ b/src/DOM/DOMProvider.php
@@ -74,9 +74,6 @@ class DOMProvider
             $a->setAttribute('data-host', $url->host());
             if ($url->inSite()) {
                 $a->setAttribute('data-insite', 'true');
-                if ($ns = $url->siteNamespace()) {
-                    $a->setAttribute('data-namespace', $ns);
-                }
             } else {
                 $a->setAttribute('data-insite', 'false');
             }
@@ -134,7 +131,7 @@ class DOMProvider
         $node = $event->getNode();
         // try to parse URL
         $url = $node->getAttribute($urlAttribute);
-        if (substr($url,0,5) == 'data:') {
+        if (substr($url, 0, 5) == 'data:') {
             return;
         }
         if (!$url || !($url = new URL($url))) {
@@ -145,6 +142,12 @@ class DOMProvider
             $event->setSource($page);
             $node->setAttribute($urlAttribute, $page->url());
             $node->setAttribute('data-link-type', 'page');
+            if ($ns = $page->url()->siteNamespace()) {
+                $node->setAttribute('data-namespace', $ns);
+            }
+            if ($page->status() != 200) {
+                $node->setAttribute('data-page-status', $page->status());
+            }
             $this->leafcutter->events()->dispatchEvent(
                 'onDOMElement_' . $node->tagName . '_page',
                 $event
@@ -155,6 +158,9 @@ class DOMProvider
         if ($includeAssets && $asset = $this->leafcutter->assets()->get($url)) {
             // dispatch event for all asset types
             $node->setAttribute('data-link-type', 'asset');
+            if ($ns = $asset->url()->siteNamespace()) {
+                $node->setAttribute('data-namespace', $ns);
+            }
             $event->setSource($asset);
             $this->leafcutter->events()->dispatchEvent(
                 'onDOMElement_' . $node->tagName . '_asset',

--- a/src/Events/EventProvider.php
+++ b/src/Events/EventProvider.php
@@ -128,7 +128,7 @@ class EventProvider
         return array_filter(
             get_class_methods($subscriber),
             function ($e) {
-                return preg_match('/^on([A-Z]+[a-z_]*[a-zA-Z])+$/', $e);
+                return preg_match('/^on([A-Z]+[a-z_]*[a-zA-Z0-9]*)+$/', $e);
             }
         );
     }

--- a/src/Indexer/Index.php
+++ b/src/Indexer/Index.php
@@ -11,6 +11,16 @@ class Index
     protected $pdo;
     protected $leafcutter;
 
+    public static function normalizeURL($url): string {
+        if ($url instanceof URL) {
+            return $url->siteFullPath() . $url->queryString();
+        }elseif (is_string($url)) {
+            return $url;
+        }else {
+            throw new \Exception("Malformed URL passed to Index", 1);
+        }
+    }
+
     public function __construct(string $name, PDO $pdo, Leafcutter $leafcutter)
     {
         $this->name = $name;
@@ -20,9 +30,7 @@ class Index
 
     public function getByURL($url): array
     {
-        if ($url instanceof URL) {
-            $url = $url->siteFullPath() . $url->queryString();
-        }
+        $url = static::normalizeURL($url);
         return $this->query(
             'SELECT * FROM "' . $this->name . '" WHERE url = :url;',
             [':url' => $url]
@@ -33,6 +41,23 @@ class Index
     {
         return $this->query(
             'SELECT * FROM "' . $this->name . '" WHERE value = :value;',
+            [':value' => $value]
+        );
+    }
+
+    public function deleteByURL($url): array
+    {
+        $url = static::normalizeURL($url);
+        return $this->query(
+            'DELETE FROM "' . $this->name . '" WHERE url = :url;',
+            [':url' => $url]
+        );
+    }
+
+    public function deleteByValue(string $value): array
+    {
+        return $this->query(
+            'DELETE FROM "' . $this->name . '" WHERE value = :value;',
             [':value' => $value]
         );
     }
@@ -96,9 +121,7 @@ class Index
 
     public function item($url, string $value, array $data = []): IndexItem
     {
-        if ($url instanceof URL) {
-            $url = $url->siteFullPath() . $url->queryString();
-        }
+        $url = static::normalizeURL($url);
         return new IndexItem($url, $value, $data, $this);
     }
 

--- a/src/Indexer/Index.php
+++ b/src/Indexer/Index.php
@@ -1,0 +1,142 @@
+<?php
+namespace Leafcutter\Indexer;
+
+use Leafcutter\Leafcutter;
+use Leafcutter\URL;
+use PDO;
+
+class Index
+{
+    protected $name;
+    protected $pdo;
+    protected $leafcutter;
+
+    public function __construct(string $name, PDO $pdo, Leafcutter $leafcutter)
+    {
+        $this->name = $name;
+        $this->pdo = $pdo;
+        $this->leafcutter = $leafcutter;
+    }
+
+    public function getByURL($url): array
+    {
+        if ($url instanceof URL) {
+            $url = $url->siteFullPath() . $url->queryString();
+        }
+        return $this->query(
+            'SELECT * FROM "' . $this->name . '" WHERE url = :url;',
+            [':url' => $url]
+        );
+    }
+
+    public function getByValue(string $value): array
+    {
+        return $this->query(
+            'SELECT * FROM "' . $this->name . '" WHERE value = :value;',
+            [':value' => $value]
+        );
+    }
+
+    public function save($url, string $value, array $data = []): IndexItem
+    {
+        $item = $this->item($url, $value, $data);
+        $item->save();
+        return $item;
+    }
+
+    public function item_delete(IndexItem $item)
+    {
+        $s = $this->pdo->prepare(
+            'DELETE FROM "' . $this->name . '" WHERE url = :url AND value = :value;'
+        );
+        return !!$s->execute([
+            ':url' => $item->urlString(),
+            ':value' => $item->value(),
+        ]);
+    }
+
+    public function item_save(IndexItem $item): bool
+    {
+        if (!$item->url()->inSite()) {
+            return false;
+        }
+        if ($this->item_exists($item)) {
+            $s = $this->pdo->prepare(
+                'UPDATE "' . $this->name . '" SET data = :data WHERE url = :url AND value = :value;'
+            );
+        } else {
+            $s = $this->pdo->prepare(
+                'INSERT INTO "' . $this->name . '" (url,value,data) VALUES (:url,:value,:data);'
+            );
+        }
+        return !!$s->execute([
+            ':url' => $item->urlString(),
+            ':value' => $item->value(),
+            ':data' => json_encode($item->data()),
+        ]);
+    }
+
+    public function item_exists(IndexItem $item): bool
+    {
+        if (!$item->url()->inSite()) {
+            return false;
+        }
+        $s = $this->pdo->prepare(
+            'SELECT * FROM "' . $this->name . '" WHERE url = :url AND value = :value;'
+        );
+        if ($s && $s->execute([
+            ':url' => $item->urlString(),
+            ':value' => $item->value(),
+        ])) {
+            return !!$s->fetch();
+        } else {
+            return false;
+        }
+    }
+
+    public function item($url, string $value, array $data = []): IndexItem
+    {
+        if ($url instanceof URL) {
+            $url = $url->siteFullPath() . $url->queryString();
+        }
+        return new IndexItem($url, $value, $data, $this);
+    }
+
+    public function create()
+    {
+        //create table
+        $this->pdo->exec(
+            $this->createTableSQL($this->name)
+        );
+        //create indexes
+        $this->pdo->exec('CREATE INDEX "url_idx" ON "' . $this->name . '" ("url");');
+        $this->pdo->exec('CREATE INDEX "value_idx" ON "' . $this->name . '" ("value");');
+    }
+
+    protected function query($sql, $params): array
+    {
+        $s = $this->pdo->prepare($sql);
+        if ($s && $s->execute($params)) {
+            return array_map(
+                function ($e) {
+                    return $this->item($e['url'], $e['value'], json_decode($e['data'], true));
+                },
+                $s->fetchAll(PDO::FETCH_ASSOC)
+            );
+        } else {
+            return [];
+        }
+    }
+
+    protected function createTableSQL(string $name): string
+    {
+        return <<<EOD
+CREATE TABLE "$name" (
+	"url"	TEXT NOT NULL,
+	"value"	TEXT NOT NULL,
+	"data"	TEXT NOT NULL,
+	PRIMARY KEY("url","value")
+);
+EOD;
+    }
+}

--- a/src/Indexer/IndexItem.php
+++ b/src/Indexer/IndexItem.php
@@ -1,0 +1,50 @@
+<?php
+namespace Leafcutter\Indexer;
+
+use Leafcutter\URL;
+
+class IndexItem
+{
+    public function __construct(string $url, string $value, array $data, Index $index)
+    {
+        $this->url = $url;
+        $this->value = $value;
+        $this->data = $data;
+        $this->index = $index;
+    }
+
+    public function url(): URL
+    {
+        return new URL('@/' . $this->url);
+    }
+
+    public function urlString(): string
+    {
+        return $this->url;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function save()
+    {
+        $this->index->item_save($this);
+    }
+
+    public function delete()
+    {
+        $this->index->item_delete($this);
+    }
+}

--- a/src/Indexer/IndexProvider.php
+++ b/src/Indexer/IndexProvider.php
@@ -1,0 +1,106 @@
+<?php
+namespace Leafcutter\Indexer;
+
+use Leafcutter\Leafcutter;
+use Leafcutter\Pages\Page;
+use Leafcutter\Pages\PageContentEvent;
+use Leafcutter\URL;
+use PDO;
+
+class IndexProvider
+{
+    protected $leafcutter;
+    protected $pdos = [];
+    protected $classes = [];
+    protected $indexes = [];
+
+    public function __construct(Leafcutter $leafcutter)
+    {
+        $this->leafcutter = $leafcutter;
+        $this->leafcutter->events()->addSubscriber($this);
+    }
+
+    public function onPageGenerateContent_finalize(PageContentEvent $event)
+    {
+        if ($uid = $event->page()->meta('uid')) {
+            $index = $this->get('uid');
+            $index->save($event->page()->url(), $uid);
+        }
+    }
+
+    public function onPageGet_namespace_uid(URL $url): ?Page
+    {
+        $results = $this->get('uid')->getByValue($url->sitePath());
+        $results = array_map(
+            function ($i) {
+                return $this->leafcutter->pages()->get($i->url());
+            },
+            $results
+        );
+        $results = array_filter($results);
+        if ($results) {
+            if (count($results) == 1) {
+                return $this->leafcutter->pages()->get($results[0]->url());
+            } else {
+                $page = $this->leafcutter->pages()->error($url, 300);
+                $page->meta('300-options', $results);
+                $page->setUrl($url);
+                return $page;
+            }
+        }
+        return null;
+    }
+
+    public function exists(string $name): bool
+    {
+        $name = $this->sanitizeName($name);
+        return is_file($this->indexFile($name));
+    }
+
+    public function get(string $name, string $class = null): ?Index
+    {
+        $name = $this->sanitizeName($name);
+        if ($class) {
+            $this->setClass($name, $class);
+        }
+        $create = !$this->exists($name);
+        if (!isset($this->indexes[$name])) {
+            $class = @$this->classes[$name] ?? Index::class;
+            $this->indexes[$name] = new $class($name, $this->pdo($name), $this->leafcutter);
+            if ($create) {
+                $this->indexes[$name]->create();
+            }
+        }
+        return $this->indexes[$name];
+    }
+
+    public function setClass(string $name, string $class)
+    {
+        $name = $this->sanitizeName($name);
+        // unset from cache if class is changed
+        if (isset($this->indexes[$name]) && !($this->indexes[$name] instanceof $class)) {
+            unset($this->indexes[$name]);
+        }
+        $this->classes[$name] = $class;
+    }
+
+    protected function sanitizeName(string $name): string
+    {
+        return preg_replace('/[^a-z0-9\-_]/', '_', strtolower($name));
+    }
+
+    protected function pdo(string $name): PDO
+    {
+        if (!isset($this->pdos[$name])) {
+            $this->pdos[$name] = new PDO(
+                'sqlite:' . $this->indexFile($name)
+            );
+        }
+        return $this->pdos[$name];
+    }
+
+    protected function indexFile($name): string
+    {
+        return $this->leafcutter->config('directories.storage') . '/' . $name . '.index.sqlite';
+    }
+}

--- a/src/Indexer/IndexProvider.php
+++ b/src/Indexer/IndexProvider.php
@@ -28,7 +28,7 @@ class IndexProvider
 
     public function onPageGenerateContent_finalize(PageContentEvent $event)
     {
-        if ($uid = $event->page()->meta('uid')) {
+        if ($event->page()->status() == 200 && $uid = $event->page()->meta('uid')) {
             $index = $this->index('uid');
             $index->save($event->page()->url(), $uid);
         }

--- a/src/Indexer/IndexProvider.php
+++ b/src/Indexer/IndexProvider.php
@@ -30,7 +30,9 @@ class IndexProvider
 
     public function onPageGet_namespace_uid(URL $url): ?Page
     {
-        $results = $this->get('uid')->getByValue($url->sitePath());
+        $url->fixSlashes();
+        $uid = trim($url->sitePath(),'/');
+        $results = $this->get('uid')->getByValue($uid);
         $results = array_map(
             function ($i) {
                 return $this->leafcutter->pages()->get($i->url());

--- a/src/Leafcutter.php
+++ b/src/Leafcutter.php
@@ -97,23 +97,14 @@ class Leafcutter
         if (!$response) {
             $response = new Response();
             $response->setURL($url);
-            $page = $this->pages()->get($url) ?? $this->events()->dispatchFirst('onResponsePageURL', $url);
-            if ($page && $normalizationRedirect) {
-                if ($bounce = URLFactory::normalizeCurrent($page->url())) {
-                    // URLFactory is requesting a URL normalization redirect, so we're done
-                    $response->redirect($bounce, 308);
-                    return $response;
-                }
-            }
-            if (!$page) {
-                $page = $this->pages()->error($url, 404);
-                $response->setStatus(404);
-            }
-            if ($page) {
-                $response->setContent($page->generateContent());
-            } else {
-                $response->setStatus(404);
-                $response->setContent('<!doctype html><html><body><h1>404 not found</h1><p>Additionally, no error page could be located.</p></body></html>');
+            $page = $this->pages()->get($url) ?? $this->events()->dispatchFirst('onResponsePageURL', $url) ?? $this->pages()->error($url, 404);
+        }
+        // normalize URL
+        if ($page && $normalizationRedirect) {
+            if ($bounce = URLFactory::normalizeCurrent($page->url())) {
+                // URLFactory is requesting a URL normalization redirect, so we're done
+                $response->redirect($bounce, 308);
+                return $response;
             }
         }
         // dispatch final events and return

--- a/src/Leafcutter.php
+++ b/src/Leafcutter.php
@@ -99,9 +99,9 @@ class Leafcutter
             $response->setURL($url);
             $page = $this->pages()->get($url) ?? $this->events()->dispatchFirst('onResponsePageURL', $url);
             if ($page && $normalizationRedirect) {
-                if (URLFactory::normalizeCurrent($page->url(), false, !$page->url()->siteNamespace())) {
+                if ($bounce = URLFactory::normalizeCurrent($page->url())) {
                     // URLFactory is requesting a URL normalization redirect, so we're done
-                    $response->redirect($page->url(), 308);
+                    $response->redirect($bounce, 308);
                     return $response;
                 }
             }

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -10,9 +10,13 @@ use Leafcutter\URLFactory;
 class Page implements PageInterface
 {
     protected $rawContent = 'No content';
-    protected $rawContentType, $generatedContent, $url, $meta;
+    protected $rawContentType;
+    protected $generatedContent;
+    protected $url;
+    protected $meta;
     protected $dynamic = false;
     protected $parent;
+    protected $status = 200;
 
     public function __construct(URL $url)
     {
@@ -26,6 +30,16 @@ class Page implements PageInterface
             'date.generated' => time(),
             'unlisted' => false,
         ]);
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
+    public function setStatus(int $status)
+    {
+        $this->status = $status;
     }
 
     public function dynamic(): bool

--- a/src/Pages/PageInterface.php
+++ b/src/Pages/PageInterface.php
@@ -17,4 +17,8 @@ interface PageInterface
     public function children(): Collection;
     public function parent(): ?PageInterface;
     public function meta(string $key, $value = null);
+    public function status(): int;
+    public function setStatus(int $status);
+    public function dynamic(): bool;
+    public function setDynamic(bool $dynamic);
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -143,6 +143,9 @@ class Response
         if (method_exists($source, 'status')) {
             $this->setStatus($source->status());
         }
+        if (method_exists($source, 'generateContent')) {
+            $this->setContent($source->generateContent());
+        }
     }
 
     public function setStatus(int $status)

--- a/src/Response.php
+++ b/src/Response.php
@@ -32,7 +32,7 @@ class Response
         foreach ($this->headers as $key => $value) {
             header("$key: $value");
         }
-        header('content-type: '.$this->mime.'; charset='.$this->charset);
+        header('content-type: ' . $this->mime . '; charset=' . $this->charset);
     }
 
     public function doAfter(callable $fn)
@@ -119,11 +119,11 @@ class Response
         return $this->source;
     }
 
-    public function page() : ?PageInterface
+    public function page(): ?PageInterface
     {
         if ($this->source instanceof PageInterface) {
             return $this->source;
-        }else {
+        } else {
             return null;
         }
     }
@@ -139,6 +139,9 @@ class Response
         }
         if (method_exists($source, 'url')) {
             $this->setURL($source->url());
+        }
+        if (method_exists($source, 'status')) {
+            $this->setStatus($source->status());
         }
     }
 

--- a/src/Templates/TemplateProvider.php
+++ b/src/Templates/TemplateProvider.php
@@ -68,6 +68,9 @@ class TemplateProvider
             function ($item) {
                 if (\is_string($item)) {
                     $item = $this->leafcutter->find($item);
+                    if (!$item) {
+                        return '[link not found]';
+                    }
                 }
                 if (\method_exists($item, 'link')) {
                     return $item->link();

--- a/src/URL.php
+++ b/src/URL.php
@@ -65,6 +65,13 @@ class URL
         $this->setFragment($parsed['fragment'] ?? '');
     }
 
+    public function fixSlashes()
+    {
+        if ($this->path() != 'favicon.ico' && !preg_match('@(/|\.html)$@', $this->path())) {
+            $this->setPath($this->path() . '/');
+        }
+    }
+
     /**
      * URL-safe base64 encoding
      *

--- a/src/URLFactory.php
+++ b/src/URLFactory.php
@@ -19,14 +19,14 @@ class URLFactory
      * @param URL $current
      * @param boolean $useScheme
      * @param boolean $fixSlashes
-     * @return boolean whether a redirect should be done
+     * @return string|null a string if a redirect should be done, otherwise null
      */
-    public static function normalizeCurrent(URL $current = null, $useScheme = false, $fixSlashes = true): bool
+    public static function normalizeCurrent(URL $current = null, $useScheme = false, $fixSlashes = true): ?string
     {
         // get computed current URL, including fixing trailing slashes if necessary
         $current = ($current ?? static::current());
-        if ($fixSlashes && $current->path() != 'favicon.ico' && !preg_match('@(/|\.html)$@', $current->path())) {
-            $current->setPath($current->path() . '/');
+        if ($fixSlashes) {
+            $current->fixSlashes();
         }
         $currentCmp = $current;
         // get actual current URL
@@ -37,7 +37,11 @@ class URLFactory
             $actualCmp = preg_replace('/^https?:/', ':', $actual);
         }
         // do comparison
-        return $currentCmp !== $actualCmp;
+        if ($currentCmp !== $actualCmp) {
+            return $current;
+        }else {
+            return null;
+        }
     }
 
     /**

--- a/src/URLFactory.php
+++ b/src/URLFactory.php
@@ -48,7 +48,9 @@ class URLFactory
     public static function currentActual(): string
     {
         $protocol = @$_SERVER['HTTPS'] === 'on' ? "https" : "http";
-        return $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        $REQUEST_URI = $_SERVER['REQUEST_URI'];
+        $REQUEST_URI = str_replace('~', '%7E', $REQUEST_URI);
+        return $protocol . '://' . $_SERVER['HTTP_HOST'] . $REQUEST_URI;
     }
 
     /**
@@ -164,5 +166,4 @@ class URLFactory
         }
         return clone $current;
     }
-
 }

--- a/tests/units/Response.php
+++ b/tests/units/Response.php
@@ -94,6 +94,8 @@ class Response extends atoum\test
             ->given($url = new \mock\Leafcutter\URL('https://www.google.com/'))
             ->given($page = new \mock\Leafcutter\Pages\PageInterface($url))
                 ->given($this->calling($page)->url = $url)
+                ->given($this->calling($page)->dynamic = false)
+                ->given($this->calling($page)->status = 200)
             ->given($this->testedInstance->setSource($page))
                 ->object($this->testedInstance->page())->isEqualTo($page)
                 ->object($this->testedInstance->source())->isEqualTo($page)

--- a/tests/units/Response.php
+++ b/tests/units/Response.php
@@ -96,6 +96,7 @@ class Response extends atoum\test
                 ->given($this->calling($page)->url = $url)
                 ->given($this->calling($page)->dynamic = false)
                 ->given($this->calling($page)->status = 200)
+                ->given($this->calling($page)->generateContent = 'foobar')
             ->given($this->testedInstance->setSource($page))
                 ->object($this->testedInstance->page())->isEqualTo($page)
                 ->object($this->testedInstance->source())->isEqualTo($page)

--- a/tests/units/URLFactory.php
+++ b/tests/units/URLFactory.php
@@ -13,11 +13,11 @@ class URLFactory extends atoum\test
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['HTTP_HOST'] = 'test.domain';
         $_SERVER['REQUEST_URI'] = '/foo/bar';
-        $this->boolean(Factory::normalizeCurrent())->isTrue();
-        $this->boolean(Factory::normalizeCurrent(new URL('https://test.domain/foo/bar')))->isTrue();
-        $this->boolean(Factory::normalizeCurrent(new URL('http://test.domain/foo/bar')))->isTrue();
-        $this->boolean(Factory::normalizeCurrent(new URL('https://test.domain/foo/bar'), false, false))->isFalse();
-        $this->boolean(Factory::normalizeCurrent(new URL('http://test.domain/foo/bar'), false, false))->isFalse();
+        $this->variable(Factory::normalizeCurrent())->isEqualTo('https://test.domain/foo/bar/');
+        $this->variable(Factory::normalizeCurrent(new URL('https://test.domain/foo/bar')))->isEqualTo('https://test.domain/foo/bar/');
+        $this->variable(Factory::normalizeCurrent(new URL('http://test.domain/foo/bar')))->isEqualTo('http://test.domain/foo/bar/');
+        $this->variable(Factory::normalizeCurrent(new URL('https://test.domain/foo/bar'), false, false))->isNull();
+        $this->variable(Factory::normalizeCurrent(new URL('http://test.domain/foo/bar'), false, false))->isNull();
         Factory::endSite();
     }
 


### PR DESCRIPTION
Default behavior is to only index by UID.

Any page can be given a UID by giving it metadata field called "uid" which can contain really any sort of string that can be sanely turned into a URL path. Such pages will then be indexed and become available at a URL like `~uid/your-uid`

Collisions are possible, and the index database does nothing to prevent them. In the case of UIDs, collisions will cause a 300 page to be generated at the UID URL that allows users to pick from all Pages currently indexed under that UID.
